### PR TITLE
feat: add users management page and sidebar link

### DIFF
--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import viteLogo from '/vite.svg';
 
 const Sidebar = () => {
@@ -9,6 +10,18 @@ const Sidebar = () => {
             <img src={viteLogo} className="logo" alt="Vite logo" />
             <h1 className="text-xl">WMS</h1>
           </div>
+          <nav className="mt-6">
+            <ul className="space-y-2">
+              <li>
+                <Link
+                  to="/users"
+                  className="block p-2 rounded hover:bg-slate-500"
+                >
+                  Users
+                </Link>
+              </li>
+            </ul>
+          </nav>
         </div>
       </div>
     </>

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { API_URL } from '@/constants';
+
+interface User {
+  id: number;
+  username: string;
+  status: string;
+  role: string;
+  lastLoginAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const Users = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const res = await axios.get(`${API_URL}/users`);
+        setUsers(res.data.items);
+      } catch {
+        setUsers([]);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  const formatDate = (dateStr: string) => {
+    if (!dateStr) return '';
+    const date = new Date(dateStr);
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+      date.getDate()
+    )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  };
+
+  return (
+    <>
+      <table className="w-full table-auto border-collapse">
+        <thead>
+          <tr className="bg-gray-200">
+            <th className="p-2 border">ID</th>
+            <th className="p-2 border">Username</th>
+            <th className="p-2 border">Status</th>
+            <th className="p-2 border">Role</th>
+            <th className="p-2 border">Last Login</th>
+            <th className="p-2 border">Created At</th>
+            <th className="p-2 border">Updated At</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr key={user.id} className="odd:bg-white even:bg-gray-50">
+              <td className="p-2 border">{user.id}</td>
+              <td className="p-2 border">{user.username}</td>
+              <td className="p-2 border">{user.status}</td>
+              <td className="p-2 border">{user.role}</td>
+              <td className="p-2 border">{formatDate(user.lastLoginAt)}</td>
+              <td className="p-2 border">{formatDate(user.createdAt)}</td>
+              <td className="p-2 border">{formatDate(user.updatedAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+export default Users;

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -1,0 +1,3 @@
+import Users from './Users';
+
+export default Users;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,6 +8,7 @@ import Login from '@/pages/login';
 import Home from '@/pages/home';
 import Profile from '@/pages/profile';
 import Settings from '@/pages/settings';
+import Users from '@/pages/users';
 
 // Importing the remote page
 import Receiving from '@/pages/receiving';
@@ -33,6 +34,7 @@ export const router = createBrowserRouter(
       children: [
         { path: '/', element: <Home /> },
         { path: '/profile', element: <Profile /> },
+        { path: '/users', element: <Users /> },
         { path: '/settings', element: <Settings /> },
 
         //remote path


### PR DESCRIPTION
## Summary
- add sidebar navigation with Users link
- create Users page that fetches and lists users
- wire up /users route

## Testing
- `pnpm lint` (fails: 6 errors in existing files)
- `pnpm test` (fails: Login.test.tsx failing assertion)


------
https://chatgpt.com/codex/tasks/task_b_68a838cd720c83328b77a2e2389084db