### PR TITLE
feat: add i18n support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "@tailwindcss/vite": "^4.1.6",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
+    "i18next": "^23.15.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.0.0",
     "react-router-dom": "^7.6.0",
     "tailwindcss": "^4.1.6",
     "zustand": "^5.0.5"

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,14 +1,39 @@
 import { Link } from 'react-router-dom';
 import { Dropdown } from '@/components/ui';
 import { useAuth } from '@/stores';
+import { useTranslation } from 'react-i18next';
 
 const Header = () => {
   const { user, logout } = useAuth();
+  const { t, i18n } = useTranslation();
+
+  const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+  };
 
   return (
     <>
       <div className="px-3 h-12 flex items-center justify-end bg-gray-500">
         <div className="flex items-center space-x-3">
+          <Dropdown>
+            <Dropdown.Trigger>
+              <button className="px-2 py-1 border rounded">
+                {i18n.language.toUpperCase()}
+              </button>
+            </Dropdown.Trigger>
+            <Dropdown.Menu>
+              <Dropdown.Item>
+                <button onClick={() => changeLanguage('en')}>
+                  {t('english')}
+                </button>
+              </Dropdown.Item>
+              <Dropdown.Item>
+                <button onClick={() => changeLanguage('vi')}>
+                  {t('vietnamese')}
+                </button>
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
           <Dropdown>
             <Dropdown.Trigger>
               <div className="w-8 h-8 rounded-full overflow-hidden">
@@ -41,12 +66,12 @@ const Header = () => {
               </div>
               <Dropdown.Item>
                 <Link to="/settings" className="block">
-                  Settings
+                  {t('settings')}
                 </Link>
               </Dropdown.Item>
               <Dropdown.Item>
                 <button className="block cursor-pointer" onClick={logout}>
-                  Logout
+                  {t('logout')}
                 </button>
               </Dropdown.Item>
             </Dropdown.Menu>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './locales/en.json';
+import vi from './locales/vi.json';
+
+const resources = {
+  en: { translation: en },
+  vi: { translation: vi },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,9 @@
+{
+  "language": "Language",
+  "english": "English",
+  "vietnamese": "Vietnamese",
+  "settings": "Settings",
+  "logout": "Logout",
+  "home": "Home",
+  "welcome": "Welcome to WMS"
+}

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1,0 +1,9 @@
+{
+  "language": "Ngôn ngữ",
+  "english": "Tiếng Anh",
+  "vietnamese": "Tiếng Việt",
+  "settings": "Cài đặt",
+  "logout": "Đăng xuất",
+  "home": "Trang chủ",
+  "welcome": "Chào mừng đến WMS"
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
+import './i18n';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,7 +1,12 @@
+import { useTranslation } from 'react-i18next';
+
 const Home = () => {
+  const { t } = useTranslation();
+
   return (
     <>
-      <h1>Home</h1>
+      <h1>{t('home')}</h1>
+      <p>{t('welcome')}</p>
     </>
   );
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,12 +9,13 @@
     "types": ["node"],
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
+      "moduleResolution": "bundler",
+      "allowImportingTsExtensions": true,
+      "verbatimModuleSyntax": true,
+      "moduleDetection": "force",
+      "noEmit": true,
+      "jsx": "react-jsx",
+      "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- add i18next configuration with English and Vietnamese translations
- provide language selector in header and localize menu labels
- show translated welcome message on home page
- store translation messages in separate en.json and vi.json files

## Testing
- `pnpm test` *(fails: expected "spy" to be called with arguments, Login.test.tsx)*


------
https://chatgpt.com/codex/tasks/task_b_68a9ecaef4b083328577676624075cee