### PR TITLE
feat: add toast component

### DIFF
--- a/src/components/ui/Dropdown/DropdownMenu.tsx
+++ b/src/components/ui/Dropdown/DropdownMenu.tsx
@@ -43,11 +43,11 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ children }) => {
         const shouldMenuOpenFromRightTrigger =
           spaceMenuToRight < menuWitdth && spaceMenuToLeft > menuWitdth;
 
-        let topPosition = shouldMenuOpenAbove
+        const topPosition = shouldMenuOpenAbove
           ? triggerRect.top - menuHeight + window.scrollY - spaceMenuToTrigger
           : triggerRect.bottom + window.scrollY + spaceMenuToTrigger;
 
-        let leftPosition = shouldMenuOpenFromRightTrigger
+        const leftPosition = shouldMenuOpenFromRightTrigger
           ? triggerRect.right - menuWitdth + window.scrollX
           : triggerRect.left + window.scrollX;
 

--- a/src/components/ui/Dropdown/DropdownTriggerClose.tsx
+++ b/src/components/ui/Dropdown/DropdownTriggerClose.tsx
@@ -14,7 +14,9 @@ const DropdownTriggerClose: React.FC<DropdownTriggerCloseProps> = ({
     return null;
   }
 
-  const element = children as React.ReactElement<any>;
+  const element = children as React.ReactElement<{
+    onClick?: (e: React.MouseEvent) => void;
+  }>;
   const childOnClick = element.props.onClick;
 
   const handleClick = (e: React.MouseEvent) => {

--- a/src/components/ui/Toast/Toast.test.tsx
+++ b/src/components/ui/Toast/Toast.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Toast from './Toast';
+
+describe('Toast', () => {
+  it('renders and closes when close button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Toast message="Hello" duration={10000} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    await waitFor(() =>
+      expect(screen.queryByText('Hello')).not.toBeInTheDocument()
+    );
+  });
+
+  it('closes automatically after the duration', () => {
+    vi.useFakeTimers();
+    render(<Toast message="Auto" duration={3000} />);
+    expect(screen.getByText('Auto')).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+      vi.runOnlyPendingTimers();
+    });
+    expect(screen.queryByText('Auto')).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it('renders in the specified placement', () => {
+    render(<Toast message="Placed" placement="bottom-left" duration={10000} />);
+    const container = screen.getByText('Placed').parentElement?.parentElement;
+    expect(container).toHaveClass('bottom-4');
+    expect(container).toHaveClass('left-4');
+  });
+});

--- a/src/components/ui/Toast/Toast.tsx
+++ b/src/components/ui/Toast/Toast.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import type { ToastProps, ToastType, ToastPlacement } from './Toast.types';
+
+const typeClasses: Record<ToastType, string> = {
+  success: 'bg-green-500 text-white',
+  error: 'bg-red-500 text-white',
+  warning: 'bg-yellow-500 text-black',
+  info: 'bg-blue-500 text-white',
+};
+
+const icons: Record<ToastType, string> = {
+  success: 'fa-solid fa-circle-check',
+  error: 'fa-solid fa-circle-xmark',
+  warning: 'fa-solid fa-triangle-exclamation',
+  info: 'fa-solid fa-circle-info',
+};
+
+const placementClasses: Record<ToastPlacement, string> = {
+  'top-right': 'top-4 right-4',
+  'top-left': 'top-4 left-4',
+  'bottom-right': 'bottom-4 right-4',
+  'bottom-left': 'bottom-4 left-4',
+};
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  type = 'info',
+  duration = 5000,
+  placement = 'top-right',
+}) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleClose();
+    }, duration);
+
+    setIsVisible(true);
+    return () => clearTimeout(timer);
+  }, [duration]);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(() => setIsOpen(false), 300);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={clsx(
+        'fixed z-50 transition-all transform duration-300',
+        placementClasses[placement],
+        isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+      )}
+    >
+      <div
+        className={clsx(
+          'flex items-center space-x-2 p-4 rounded shadow',
+          typeClasses[type]
+        )}
+      >
+        <i className={clsx(icons[type])}></i>
+        <span className="mr-4">{message}</span>
+        <button onClick={handleClose} aria-label="close-toast">
+          <i className="fa-solid fa-xmark" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/ui/Toast/Toast.types.ts
+++ b/src/components/ui/Toast/Toast.types.ts
@@ -1,0 +1,14 @@
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export type ToastPlacement =
+  | 'top-right'
+  | 'top-left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+export interface ToastProps {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+  placement?: ToastPlacement;
+}

--- a/src/components/ui/Toast/index.ts
+++ b/src/components/ui/Toast/index.ts
@@ -1,0 +1,4 @@
+import Toast from './Toast';
+
+export default Toast;
+export * from './Toast.types';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,5 +2,6 @@ import Button from './Button';
 import Dropdown from './Dropdown';
 import Input from './Input';
 import GlobalLoading from './GlobalLoading';
+import Toast from './Toast';
 
-export { Button, Dropdown, Input, GlobalLoading };
+export { Button, Dropdown, Input, GlobalLoading, Toast };


### PR DESCRIPTION
## Summary
- add animated Toast component with type styling and optional duration
- support four placements and closable action
- test toast behavior and mock axios in login test
- fix dropdown components to satisfy lint rules

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aa6a9f3bc88332aa9dc0c388aefd32