### PR TITLE
chore: enable top level await support

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,14 @@ export default defineConfig({
       '@assets': path.resolve(__dirname, './src/assets'),
     },
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
+  build: {
+    target: 'esnext',
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- allow top level await by setting esbuild target to esnext

## Testing
- `npm test` (fails: Network Error and assertion failure in login test)
- `npm run build` (fails: missing i18next/react-i18next modules)


------
https://chatgpt.com/codex/tasks/task_b_68aaa98c93608332b2da3cba305e49a9