### PR TITLE
feat: add checkbox component

### DIFF
--- a/src/components/ui/Checkbox/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import Checkbox from './Checkbox';
+
+describe('Checkbox', () => {
+  it('renders with label', () => {
+    render(<Checkbox label="Accept" />);
+    expect(screen.getByLabelText('Accept')).toBeInTheDocument();
+  });
+
+  it('toggles when clicked', async () => {
+    const user = userEvent.setup();
+    render(<Checkbox label="Agree" />);
+    const checkbox = screen.getByLabelText('Agree') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    await user.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('is disabled when disabled prop is true', async () => {
+    const user = userEvent.setup();
+    render(<Checkbox label="Disabled" disabled />);
+    const checkbox = screen.getByLabelText('Disabled') as HTMLInputElement;
+    expect(checkbox).toBeDisabled();
+    await user.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('applies size and variant classes', () => {
+    render(<Checkbox label="Size" size="lg" variant="solid" />);
+    const checkbox = screen.getByLabelText('Size');
+    expect(checkbox.className).toContain('h-6 w-6');
+    expect(checkbox.className).toContain('bg-blue-600');
+  });
+});

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import clsx from 'clsx';
+import type {
+  CheckboxProps,
+  CheckboxSizeType,
+  CheckboxVariantType,
+} from './Checkbox.types';
+
+const sizeClasses: Record<CheckboxSizeType, string> = {
+  xs: 'h-3 w-3',
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+const variantClasses: Record<CheckboxVariantType, string> = {
+  outline: 'bg-white border-gray-300 text-blue-600 focus:ring-blue-500',
+  solid: 'bg-blue-600 border-blue-600 text-white focus:ring-blue-500',
+  subtle: 'bg-blue-100 border-blue-200 text-blue-600 focus:ring-blue-500',
+};
+
+const Checkbox: React.FC<CheckboxProps> = ({
+  size = 'md',
+  variant = 'outline',
+  label,
+  disabled = false,
+  className,
+  ...rest
+}) => {
+  const baseClasses = `rounded transition-colors duration-150 ${
+    disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+  }`;
+
+  return (
+    <label className="inline-flex items-center">
+      <input
+        type="checkbox"
+        disabled={disabled}
+        className={clsx(
+          'form-checkbox',
+          baseClasses,
+          sizeClasses[size],
+          variantClasses[variant],
+          className
+        )}
+        {...rest}
+      />
+      {label && <span className="ml-2 select-none">{label}</span>}
+    </label>
+  );
+};
+
+export default Checkbox;

--- a/src/components/ui/Checkbox/Checkbox.types.ts
+++ b/src/components/ui/Checkbox/Checkbox.types.ts
@@ -1,0 +1,10 @@
+export type CheckboxSizeType = 'xs' | 'sm' | 'md' | 'lg';
+
+export type CheckboxVariantType = 'outline' | 'solid' | 'subtle';
+
+export interface CheckboxProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  size?: CheckboxSizeType;
+  variant?: CheckboxVariantType;
+  label?: React.ReactNode;
+}

--- a/src/components/ui/Checkbox/index.ts
+++ b/src/components/ui/Checkbox/index.ts
@@ -1,0 +1,3 @@
+import Checkbox from './Checkbox';
+
+export default Checkbox;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,5 +5,15 @@ import GlobalLoading from './GlobalLoading';
 import Modal from './Modal';
 import Drawer from './Drawer';
 import Accordion from './Accordion';
+import Checkbox from './Checkbox';
 
-export { Button, Dropdown, Input, GlobalLoading, Modal, Drawer, Accordion };
+export {
+  Button,
+  Dropdown,
+  Input,
+  GlobalLoading,
+  Modal,
+  Drawer,
+  Accordion,
+  Checkbox,
+};


### PR DESCRIPTION
## Summary
- add reusable Checkbox component with size, variant, and disabled support
- include tests and export component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Unable to find a label with the text of: close-toast)*

------
https://chatgpt.com/codex/tasks/task_b_68aee3ef580c8332b0d3407ec94907f0