### PR TITLE
Refactor Table component for new API format

### DIFF
--- a/src/components/ui/Table/Table.types.ts
+++ b/src/components/ui/Table/Table.types.ts
@@ -17,6 +17,7 @@ export interface TableSourceConfig {
   api: string; // e.g. 'localhost://8080/users' or full URL
   schema?: string;
   table?: string;
+  defaultSorts?: { field: string; asc: boolean }[];
 }
 
 export interface TablePaginationConfig {
@@ -51,5 +52,7 @@ export interface TableProps {
   /**
    * Optional loader to fully override fetching logic (useful for mocks).
    */
-  loadData?: (params: TableFetchParams & { searchableKeys?: string[] }) => Promise<{ items: Row[]; total: number }>;
+  loadData?: (
+    params: TableFetchParams & { searchableKeys?: string[] }
+  ) => Promise<{ items: Row[]; total: number }>;
 }


### PR DESCRIPTION
## Summary
- handle API fields with `{ value }` wrappers in table responses
- send table queries via POST with filters, sorting, and pagination
- allow configuring default sorts in table source config

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_b_68b16555607c833290b9b6ec96e834b4