### PR TITLE
feat: remove toast visibility limits

### DIFF
--- a/src/components/ui/Toast/ToastContainer.test.tsx
+++ b/src/components/ui/Toast/ToastContainer.test.tsx
@@ -8,49 +8,20 @@ describe('ToastContainer', () => {
     vi.clearAllMocks();
   });
 
-  it('limits visible toasts when enabled', async () => {
+  it('renders all toasts', async () => {
     const { ToastContainer } = await import('.');
     const { useToastStore } = await import('@/stores');
-    const { MAX_VISIBLE_TOASTS } = await import('@/constants');
     const { showToast } = useToastStore.getState();
+
     act(() => {
-      for (let i = 0; i < MAX_VISIBLE_TOASTS + 2; i++) {
+      for (let i = 0; i < 12; i++) {
         showToast({ message: `Toast ${i}` });
       }
     });
 
     render(<ToastContainer />);
 
-    expect(screen.getAllByLabelText('close-toast').length).toBe(
-      MAX_VISIBLE_TOASTS,
-    );
-  });
-
-  it('renders all toasts when limit disabled', async () => {
-    vi.doMock('@/constants', async () => {
-      const actual = await vi.importActual<typeof import('@/constants')>(
-        '@/constants',
-      );
-      return {
-        ...actual,
-        LIMITED_TOAST_NUMBER: false,
-      };
-    });
-    const { ToastContainer } = await import('.');
-    const { useToastStore } = await import('@/stores');
-    const { MAX_VISIBLE_TOASTS } = await import('@/constants');
-    const { showToast } = useToastStore.getState();
-    act(() => {
-      for (let i = 0; i < MAX_VISIBLE_TOASTS + 2; i++) {
-        showToast({ message: `Toast ${i}` });
-      }
-    });
-
-    render(<ToastContainer />);
-
-    expect(screen.getAllByLabelText('close-toast').length).toBe(
-      MAX_VISIBLE_TOASTS + 2,
-    );
+    expect(screen.getAllByLabelText('close-toast').length).toBe(12);
   });
 
   it('stacks toasts vertically', async () => {

--- a/src/components/ui/Toast/ToastContainer.tsx
+++ b/src/components/ui/Toast/ToastContainer.tsx
@@ -1,5 +1,4 @@
 import { useToastStore } from '@/stores';
-import { LIMITED_TOAST_NUMBER, MAX_VISIBLE_TOASTS } from '@/constants';
 import Toast from './Toast';
 import type { ToastPlacement } from './Toast.types';
 
@@ -25,28 +24,23 @@ const ToastContainer = () => {
 
   return (
     <>
-      {Object.entries(grouped).map(([placement, list]) => {
-        const visibleList = LIMITED_TOAST_NUMBER
-          ? list.slice(0, MAX_VISIBLE_TOASTS)
-          : list;
-        return (
-          <div
-            key={placement}
-            className={placementClasses[placement as ToastPlacement]}
-            data-testid={`toast-group-${placement}`}
-          >
-            {visibleList.map((toast) => (
-              <Toast
-                key={toast.id}
-                message={toast.message}
-                type={toast.type}
-                duration={toast.duration}
-                onClose={() => removeToast(toast.id)}
-              />
-            ))}
-          </div>
-        );
-      })}
+      {Object.entries(grouped).map(([placement, list]) => (
+        <div
+          key={placement}
+          className={placementClasses[placement as ToastPlacement]}
+          data-testid={`toast-group-${placement}`}
+        >
+          {list.map((toast) => (
+            <Toast
+              key={toast.id}
+              message={toast.message}
+              type={toast.type}
+              duration={toast.duration}
+              onClose={() => removeToast(toast.id)}
+            />
+          ))}
+        </div>
+      ))}
     </>
   );
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,2 @@
 export { API, API_URL } from './apiUrl';
 export { messageCodeMap } from './messageCodeMap';
-export { MAX_VISIBLE_TOASTS, LIMITED_TOAST_NUMBER } from './toast';

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -1,2 +1,0 @@
-export const LIMITED_TOAST_NUMBER = true;
-export const MAX_VISIBLE_TOASTS = 10;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,4 +1,4 @@
-export const debounce = <T extends (...args: any[]) => void>(
+export const debounce = <T extends (...args: unknown[]) => void>(
   fn: T,
   delay = 300
 ) => {


### PR DESCRIPTION
## Summary
- remove toast visibility limit constants and show all toasts
- update toast container tests
- fix debounce util type for lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b9bad4caf08332a309b505c7b1d096