### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
 
   useEffect(() => {
     checkAuth();
-  }, []);
+  }, [checkAuth]);
 
   return (
     <>

--- a/src/components/ui/Accordion/Accordion.test.tsx
+++ b/src/components/ui/Accordion/Accordion.test.tsx
@@ -7,7 +7,7 @@ describe('Accordion', () => {
     render(
       <Accordion title="Title">
         <div>Content</div>
-      </Accordion>,
+      </Accordion>
     );
     const button = screen.getByRole('button', { name: 'Title' });
     const icon = screen.getByTestId('accordion-icon');

--- a/src/components/ui/Accordion/Accordion.tsx
+++ b/src/components/ui/Accordion/Accordion.tsx
@@ -13,7 +13,11 @@ const sizeClasses: Record<NonNullable<AccordionProps['size']>, string> = {
   lg: 'text-lg',
 };
 
-const Accordion: React.FC<AccordionProps> = ({ title, size = 'md', children }) => {
+const Accordion: React.FC<AccordionProps> = ({
+  title,
+  size = 'md',
+  children,
+}) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -21,7 +25,10 @@ const Accordion: React.FC<AccordionProps> = ({ title, size = 'md', children }) =
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className={clsx('w-full flex justify-between items-center p-4', sizeClasses[size])}
+        className={clsx(
+          'w-full flex justify-between items-center p-4',
+          sizeClasses[size]
+        )}
         aria-expanded={open}
       >
         <span>{title}</span>
@@ -35,7 +42,7 @@ const Accordion: React.FC<AccordionProps> = ({ title, size = 'md', children }) =
       <div
         className={clsx(
           'overflow-hidden transition-all duration-200',
-          open ? 'max-h-screen' : 'max-h-0',
+          open ? 'max-h-screen' : 'max-h-0'
         )}
       >
         <div className="p-4 border-t">{children}</div>

--- a/src/components/ui/Drawer/Drawer.test.tsx
+++ b/src/components/ui/Drawer/Drawer.test.tsx
@@ -7,7 +7,7 @@ describe('Drawer', () => {
     render(
       <Drawer isOpen onClose={() => {}}>
         <div>Content</div>
-      </Drawer>,
+      </Drawer>
     );
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
@@ -17,7 +17,7 @@ describe('Drawer', () => {
     render(
       <Drawer isOpen onClose={onClose}>
         <div>Content</div>
-      </Drawer>,
+      </Drawer>
     );
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
@@ -27,7 +27,7 @@ describe('Drawer', () => {
     render(
       <Drawer isOpen onClose={() => {}}>
         <div>Content</div>
-      </Drawer>,
+      </Drawer>
     );
     const container = screen.getByTestId('drawer-container');
     expect(container.classList.contains('justify-end')).toBe(true);

--- a/src/components/ui/Dropdown/DropdownContext.tsx
+++ b/src/components/ui/Dropdown/DropdownContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext } from 'react';
 
 interface DropdownContextProps {
@@ -9,11 +10,11 @@ interface DropdownContextProps {
 
 const DropdownContext = createContext<DropdownContextProps | null>(null);
 
-function useDropdownContext() {
+const useDropdownContext = () => {
   const ctx = useContext(DropdownContext);
   if (!ctx)
     throw new Error('Dropdown.* components must be used within Dropdown');
   return ctx;
-}
+};
 
 export { DropdownContext, useDropdownContext };

--- a/src/components/ui/Dropdown/DropdownMenu.tsx
+++ b/src/components/ui/Dropdown/DropdownMenu.tsx
@@ -67,7 +67,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ children }) => {
       window.removeEventListener('scroll', updatePosition, true);
       window.removeEventListener('resize', updatePosition);
     };
-  }, [isOpen, triggerRef]);
+  }, [isOpen, triggerRef, menuRef]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {

--- a/src/components/ui/Modal/Modal.test.tsx
+++ b/src/components/ui/Modal/Modal.test.tsx
@@ -82,7 +82,13 @@ describe('Modal', () => {
       </Modal>
     );
     const closeButton = screen.getByTestId('modal-close');
-    expect(closeButton).toHaveClass('w-9', 'h-9', 'top-2', 'right-2', 'rounded-md');
+    expect(closeButton).toHaveClass(
+      'w-9',
+      'h-9',
+      'top-2',
+      'right-2',
+      'rounded-md'
+    );
   });
 
   it('places footer at bottom with actions aligned right', () => {
@@ -109,7 +115,9 @@ describe('Modal', () => {
     );
     const modalRoot = document.getElementById('modal-root');
     expect(modalRoot).toBeInTheDocument();
-    expect(modalRoot?.querySelector('[data-testid="modal-content"]')).toBeInTheDocument();
+    expect(
+      modalRoot?.querySelector('[data-testid="modal-content"]')
+    ).toBeInTheDocument();
   });
 
   it('applies cover size padding, dimensions, and centered placement', () => {

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -40,7 +40,8 @@ const Modal: React.FC<ModalProps> & {
   className,
   ...rest
 }) => {
-  const { isMounted, isVisible, handleAnimationEnd } = useAnimatedUnmount(isOpen);
+  const { isMounted, isVisible, handleAnimationEnd } =
+    useAnimatedUnmount(isOpen);
   const portalRef = useRef<HTMLDivElement | null>(null);
 
   if (!portalRef.current && typeof document !== 'undefined') {

--- a/src/components/ui/Modal/ModalBody.tsx
+++ b/src/components/ui/Modal/ModalBody.tsx
@@ -7,7 +7,10 @@ const ModalBody: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
   ...rest
 }) => {
   return (
-    <div className={clsx('flex-1 px-4 py-2 overflow-y-auto', className)} {...rest}>
+    <div
+      className={clsx('flex-1 px-4 py-2 overflow-y-auto', className)}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/components/ui/Modal/ModalFooter.tsx
+++ b/src/components/ui/Modal/ModalFooter.tsx
@@ -7,7 +7,10 @@ const ModalFooter: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
   ...rest
 }) => {
   return (
-    <div className={clsx('mt-auto px-4 py-2 flex justify-end', className)} {...rest}>
+    <div
+      className={clsx('mt-auto px-4 py-2 flex justify-end', className)}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/components/ui/Table/index.ts
+++ b/src/components/ui/Table/index.ts
@@ -1,3 +1,2 @@
 import Table from './Table';
 export default Table;
-

--- a/src/components/ui/Toast/Toast.test.tsx
+++ b/src/components/ui/Toast/Toast.test.tsx
@@ -8,7 +8,8 @@ describe('Toast', () => {
     const user = userEvent.setup();
     render(<Toast message="Hello" duration={10000} />);
     expect(screen.getByText('Hello')).toBeInTheDocument();
-    const container = screen.getByText('Hello').parentElement?.parentElement as HTMLElement;
+    const container = screen.getByText('Hello').parentElement
+      ?.parentElement as HTMLElement;
     await user.click(screen.getByRole('button'));
     fireEvent.transitionEnd(container);
     await waitFor(() =>
@@ -19,10 +20,10 @@ describe('Toast', () => {
   it('closes automatically after the duration', () => {
     render(<Toast message="Auto" duration={3000} />);
     expect(screen.getByText('Auto')).toBeInTheDocument();
-    const container = screen.getByText('Auto').parentElement?.parentElement as HTMLElement;
+    const container = screen.getByText('Auto').parentElement
+      ?.parentElement as HTMLElement;
     fireEvent.animationEnd(container);
     fireEvent.transitionEnd(container);
     expect(screen.queryByText('Auto')).not.toBeInTheDocument();
   });
-
 });

--- a/src/constants/apiUrl.ts
+++ b/src/constants/apiUrl.ts
@@ -17,5 +17,6 @@ export const API = {
   ADD_USER: `${API_URL}/users`,
   DELETE_USER: (id: number) => `${API_URL}/users/${id}`,
   CHANGE_PASSWORD: (id: number) => `${API_URL}/users/${id}/password`,
-  UNLOCK_ACCOUNT: (id: number) => `${API_URL}/users/${id}/reset-failed-attempts`,
+  UNLOCK_ACCOUNT: (id: number) =>
+    `${API_URL}/users/${id}/reset-failed-attempts`,
 };

--- a/src/pages/login/Login.test.tsx
+++ b/src/pages/login/Login.test.tsx
@@ -4,9 +4,10 @@ import userEvent from '@testing-library/user-event';
 const mockNavigate = vi.fn();
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom'
-  );
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/src/routes/RedirectIfAuthenticated.tsx
+++ b/src/routes/RedirectIfAuthenticated.tsx
@@ -15,7 +15,7 @@ const RedirectIfAuthenticated = ({
     if (!isAuthLoading && user) {
       navigate('/', { replace: true });
     }
-  }, [user, isAuthLoading]);
+  }, [user, isAuthLoading, navigate]);
 
   if (isAuthLoading) return <GlobalLoading />;
 

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
-import type { ToastType, ToastPlacement } from '@/components/ui/Toast/Toast.types';
+import type {
+  ToastType,
+  ToastPlacement,
+} from '@/components/ui/Toast/Toast.types';
 
 interface ToastOptions {
   id: number;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,13 +9,13 @@
     "types": ["node"],
 
     /* Bundler mode */
-      "moduleResolution": "bundler",
-      "allowImportingTsExtensions": true,
-      "verbatimModuleSyntax": true,
-      "moduleDetection": "force",
-      "noEmit": true,
-      "jsx": "react-jsx",
-      "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- ensure authentication and navigation effects include all dependencies
- quiet react-refresh warning in DropdownContext
- update dropdown menu positioning effect dependencies

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_b_68b9bf96fc688332b89bc7eb3025a0cc