### PR TITLE
feat: add sortable table headers

### DIFF
--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -57,6 +57,10 @@ const Table: React.FC<TableProps> = ({
   const [filterValue, setFilterValue] = useState<string>('');
   const [appliedFilterKey, setAppliedFilterKey] = useState<string>('');
   const [appliedFilterValue, setAppliedFilterValue] = useState<string>('');
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc' | null>(
+    null
+  );
 
   const filterableColumns = useMemo(
     () => columns.filter((c) => c.filterable),
@@ -80,6 +84,13 @@ const Table: React.FC<TableProps> = ({
           search: searchTerm || undefined,
           filterKey: appliedFilterKey || undefined,
           filterValue: appliedFilterValue || undefined,
+          sortField: sortKey || undefined,
+          sortAsc:
+            sortDirection === 'asc'
+              ? true
+              : sortDirection === 'desc'
+                ? false
+                : undefined,
           searchableKeys: searchableColumns.map((c) => c.key),
         });
         setData(result.items);
@@ -109,7 +120,10 @@ const Table: React.FC<TableProps> = ({
           schema: source.schema,
           page,
           page_size: size,
-          default_sorts: source.defaultSorts,
+          default_sorts:
+            sortKey && sortDirection
+              ? [{ field: sortKey, asc: sortDirection === 'asc' }]
+              : source.defaultSorts,
           filters: filters.length ? filters : undefined,
         };
 
@@ -145,6 +159,8 @@ const Table: React.FC<TableProps> = ({
     searchableColumns,
     mapResponse,
     loadData,
+    sortKey,
+    sortDirection,
   ]);
 
   useEffect(() => {
@@ -176,6 +192,21 @@ const Table: React.FC<TableProps> = ({
     setFilterValue('');
     setAppliedFilterKey('');
     setAppliedFilterValue('');
+    setPage(1);
+  };
+
+  const handleSort = (key: string) => {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortDirection('asc');
+    } else if (sortDirection === 'asc') {
+      setSortDirection('desc');
+    } else if (sortDirection === 'desc') {
+      setSortKey(null);
+      setSortDirection(null);
+    } else {
+      setSortDirection('asc');
+    }
     setPage(1);
   };
 
@@ -214,6 +245,9 @@ const Table: React.FC<TableProps> = ({
         error={error}
         data={data}
         columns={columns}
+        sortKey={sortKey}
+        sortDirection={sortDirection}
+        onSort={handleSort}
       />
       <TablePagination
         page={page}

--- a/src/components/ui/Table/Table.types.ts
+++ b/src/components/ui/Table/Table.types.ts
@@ -45,6 +45,8 @@ export interface TableFetchParams {
   search?: string;
   filterKey?: string;
   filterValue?: string;
+  sortField?: string;
+  sortAsc?: boolean;
 }
 
 export interface TableProps {
@@ -83,6 +85,9 @@ export interface TableContentProps {
   error: Error | null;
   data: Row[];
   columns: TableColumn[];
+  sortKey: string | null;
+  sortDirection: 'asc' | 'desc' | null;
+  onSort: (field: string) => void;
 }
 
 export interface TablePaginationProps {

--- a/src/components/ui/Table/TableContent.tsx
+++ b/src/components/ui/Table/TableContent.tsx
@@ -7,6 +7,9 @@ const TableContent: React.FC<TableContentProps> = ({
   error,
   data,
   columns,
+  sortKey,
+  sortDirection,
+  onSort,
 }) => {
   return (
     <div
@@ -30,14 +33,35 @@ const TableContent: React.FC<TableContentProps> = ({
           <table className="w-full table-auto border-collapse">
             <thead>
               <tr className="bg-gray-100">
-                {columns.map((col) => (
-                  <th
-                    key={col.key}
-                    className="p-2 border text-left font-semibold text-gray-700"
-                  >
-                    {col.label}
-                  </th>
-                ))}
+                {columns.map((col) => {
+                  const isSorted = sortKey === col.key;
+                  let icon = 'fa-sort';
+                  let color = 'text-gray-400';
+                  if (isSorted && sortDirection === 'asc') {
+                    icon = 'fa-sort-up';
+                    color = 'text-green-500';
+                  } else if (isSorted && sortDirection === 'desc') {
+                    icon = 'fa-sort-down';
+                    color = 'text-red-500';
+                  }
+                  return (
+                    <th
+                      key={col.key}
+                      className="p-2 border font-semibold text-gray-700 text-center"
+                    >
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => onSort(col.key)}
+                          className="flex items-center justify-center cursor-pointer"
+                        >
+                          <i className={`fa-solid ${icon} ${color}`} />
+                        </button>
+                        <span>{col.label}</span>
+                      </div>
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- add sort field parameters to table types
- support toggling ascending/descending/reset sorting in table component
- show clickable sort icons with color cues in table headers

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_b_68bfe795e4908332b1dcd0400907d265