### PR TITLE
Refactor Drawer to use Portal and add subcomponents

### DIFF
--- a/src/components/ui/Drawer/Drawer.context.ts
+++ b/src/components/ui/Drawer/Drawer.context.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+interface DrawerContextValue {
+  onClose: () => void;
+}
+
+const DrawerContext = createContext<DrawerContextValue | undefined>(undefined);
+
+export const DrawerProvider = DrawerContext.Provider;
+
+export const useDrawerContext = () => {
+  const context = useContext(DrawerContext);
+
+  if (!context) {
+    throw new Error('Drawer components must be used within a Drawer.');
+  }
+
+  return context;
+};

--- a/src/components/ui/Drawer/Drawer.test.tsx
+++ b/src/components/ui/Drawer/Drawer.test.tsx
@@ -6,7 +6,10 @@ describe('Drawer', () => {
   it('renders when open', () => {
     render(
       <Drawer isOpen onClose={() => {}}>
-        <div>Content</div>
+        <Drawer.Header title="Drawer title" />
+        <Drawer.Body>
+          <div>Content</div>
+        </Drawer.Body>
       </Drawer>
     );
     expect(screen.getByText('Content')).toBeInTheDocument();
@@ -16,7 +19,10 @@ describe('Drawer', () => {
     const onClose = vi.fn();
     render(
       <Drawer isOpen onClose={onClose}>
-        <div>Content</div>
+        <Drawer.Header title="Drawer title" />
+        <Drawer.Body>
+          <div>Content</div>
+        </Drawer.Body>
       </Drawer>
     );
     fireEvent.keyDown(document, { key: 'Escape' });
@@ -26,10 +32,28 @@ describe('Drawer', () => {
   it('defaults to end placement', () => {
     render(
       <Drawer isOpen onClose={() => {}}>
-        <div>Content</div>
+        <Drawer.Header title="Drawer title" />
+        <Drawer.Body>
+          <div>Content</div>
+        </Drawer.Body>
       </Drawer>
     );
     const container = screen.getByTestId('drawer-container');
     expect(container.classList.contains('justify-end')).toBe(true);
+  });
+
+  it('closes when clicking on header close button', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer isOpen onClose={onClose}>
+        <Drawer.Header title="Drawer title" />
+        <Drawer.Body>
+          <div>Content</div>
+        </Drawer.Body>
+      </Drawer>
+    );
+
+    fireEvent.click(screen.getByTestId('drawer-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/Drawer/Drawer.tsx
+++ b/src/components/ui/Drawer/Drawer.tsx
@@ -1,7 +1,11 @@
-import React, { useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import type { DrawerProps, DrawerSize, DrawerPlacement } from './Drawer.types';
+import DrawerHeader from './DrawerHeader';
+import DrawerBody from './DrawerBody';
+import DrawerFooter from './DrawerFooter';
+import { DrawerProvider } from './Drawer.context';
+import Portal from '../Portal';
 import { useAnimatedUnmount } from '@/hooks';
 
 const widthClasses: Record<DrawerSize, string> = {
@@ -20,7 +24,11 @@ const heightClasses: Record<DrawerSize, string> = {
   full: 'h-full',
 };
 
-const Drawer: React.FC<DrawerProps> = ({
+const Drawer: React.FC<DrawerProps> & {
+  Header: typeof DrawerHeader;
+  Body: typeof DrawerBody;
+  Footer: typeof DrawerFooter;
+} = ({
   isOpen,
   onClose,
   size = 'md',
@@ -28,38 +36,18 @@ const Drawer: React.FC<DrawerProps> = ({
   disableClickBackdrop = false,
   children,
   className,
-  title,
   ...rest
 }) => {
   const { isMounted, isVisible, handleAnimationEnd } =
     useAnimatedUnmount(isOpen);
-  const portalRef = useRef<HTMLDivElement | null>(null);
-
-  if (!portalRef.current && typeof document !== 'undefined') {
-    portalRef.current = document.createElement('div');
-  }
-
-  useEffect(() => {
-    const root =
-      document.getElementById('drawer-root') ||
-      (() => {
-        const el = document.createElement('div');
-        el.setAttribute('id', 'drawer-root');
-        document.body.appendChild(el);
-        return el;
-      })();
-    const el = portalRef.current!;
-    root.appendChild(el);
-    return () => {
-      root.removeChild(el);
-    };
-  }, []);
 
   useEffect(() => {
     if (!isOpen) return;
+
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
+
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
   }, [isOpen, onClose]);
@@ -104,42 +92,34 @@ const Drawer: React.FC<DrawerProps> = ({
     }
   };
 
-  const drawer = (
-    <div className="fixed inset-0 z-50" {...rest}>
-      <div className={overlayClasses} data-testid="drawer-overlay" />
-      <div
-        className={containerClasses}
-        data-testid="drawer-container"
-        onMouseDown={handleBackdropClick}
-      >
+  return (
+    <Portal containerId="drawer-root">
+      <div className="fixed inset-0 z-50" {...rest}>
+        <div className={overlayClasses} data-testid="drawer-overlay" />
         <div
-          className={contentClasses}
-          role="dialog"
-          aria-modal="true"
-          data-testid="drawer-content"
-          onAnimationEnd={handleAnimationEnd}
+          className={containerClasses}
+          data-testid="drawer-container"
+          onMouseDown={handleBackdropClick}
         >
-          <div className="drawer-close">
-            <button
-              type="button"
-              aria-label="Close"
-              onClick={onClose}
-              className="absolute top-2 right-2 w-9 h-9 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md cursor-pointer"
-              data-testid="modal-close"
+          <DrawerProvider value={{ onClose }}>
+            <div
+              className={contentClasses}
+              role="dialog"
+              aria-modal="true"
+              data-testid="drawer-content"
+              onAnimationEnd={handleAnimationEnd}
             >
-              <i className="fa-solid fa-xmark" />
-            </button>
-          </div>
-          <div className="drawer-header pl-5 pr-12 py-4">
-            <h2 className="text-2xl">{title}</h2>
-          </div>
-          <div className="h-full">{children}</div>
+              {children}
+            </div>
+          </DrawerProvider>
         </div>
       </div>
-    </div>
+    </Portal>
   );
-
-  return portalRef.current ? createPortal(drawer, portalRef.current) : null;
 };
+
+Drawer.Header = DrawerHeader;
+Drawer.Body = DrawerBody;
+Drawer.Footer = DrawerFooter;
 
 export default Drawer;

--- a/src/components/ui/Drawer/Drawer.types.ts
+++ b/src/components/ui/Drawer/Drawer.types.ts
@@ -1,13 +1,14 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
 export type DrawerSize = 'xs' | 'sm' | 'md' | 'lg' | 'full';
 export type DrawerPlacement = 'start' | 'end' | 'top' | 'bottom';
 
-export interface DrawerProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface DrawerProps extends HTMLAttributes<HTMLDivElement> {
   isOpen: boolean;
   onClose: () => void;
   size?: DrawerSize;
   placement?: DrawerPlacement;
   disableClickBackdrop?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
-  title?: string;
 }

--- a/src/components/ui/Drawer/DrawerBody.tsx
+++ b/src/components/ui/Drawer/DrawerBody.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+
+const DrawerBody: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  return (
+    <div
+      className={clsx('flex-1 px-5 py-4 overflow-y-auto', className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DrawerBody;

--- a/src/components/ui/Drawer/DrawerFooter.tsx
+++ b/src/components/ui/Drawer/DrawerFooter.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+
+const DrawerFooter: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  return (
+    <div
+      className={clsx('px-5 py-4 border-t border-gray-100 flex justify-end gap-2', className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DrawerFooter;

--- a/src/components/ui/Drawer/DrawerHeader.tsx
+++ b/src/components/ui/Drawer/DrawerHeader.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useDrawerContext } from './Drawer.context';
+
+export interface DrawerHeaderProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  title?: React.ReactNode;
+  showCloseButton?: boolean;
+}
+
+const DrawerHeader: React.FC<DrawerHeaderProps> = ({
+  children,
+  className,
+  title,
+  showCloseButton = true,
+  ...rest
+}) => {
+  const { onClose } = useDrawerContext();
+
+  const content =
+    children ??
+    (title ? (
+      <h2 className="text-2xl font-semibold text-gray-900">{title}</h2>
+    ) : null);
+
+  return (
+    <div
+      className={clsx(
+        'flex items-center justify-between gap-4 px-5 py-4 border-b border-gray-100',
+        className
+      )}
+      {...rest}
+    >
+      <div className="flex-1 min-w-0 text-left">{content}</div>
+      {showCloseButton && (
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="ml-3 w-9 h-9 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md cursor-pointer"
+          data-testid="drawer-close"
+        >
+          <i className="fa-solid fa-xmark" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DrawerHeader;

--- a/src/components/ui/Drawer/index.ts
+++ b/src/components/ui/Drawer/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Drawer';
 export type { DrawerProps, DrawerSize, DrawerPlacement } from './Drawer.types';
+export type { DrawerHeaderProps } from './DrawerHeader';

--- a/src/components/ui/Portal/Portal.tsx
+++ b/src/components/ui/Portal/Portal.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface PortalProps {
+  children: ReactNode;
+  containerId: string;
+}
+
+const Portal = ({ children, containerId }: PortalProps) => {
+  const portalRef = useRef<HTMLDivElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    if (!portalRef.current) {
+      portalRef.current = document.createElement('div');
+    }
+
+    let root = document.getElementById(containerId);
+    if (!root) {
+      root = document.createElement('div');
+      root.setAttribute('id', containerId);
+      document.body.appendChild(root);
+    }
+
+    const element = portalRef.current;
+    root.appendChild(element);
+    setMounted(true);
+
+    return () => {
+      root?.removeChild(element);
+      if (root && root.childNodes.length === 0) {
+        root.parentNode?.removeChild(root);
+      }
+      setMounted(false);
+    };
+  }, [containerId]);
+
+  if (!mounted || !portalRef.current) return null;
+
+  return createPortal(children, portalRef.current);
+};
+
+export default Portal;

--- a/src/components/ui/Portal/index.ts
+++ b/src/components/ui/Portal/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Portal';
+export type { PortalProps } from './Portal';

--- a/src/pages/guest/Guest.tsx
+++ b/src/pages/guest/Guest.tsx
@@ -18,10 +18,13 @@ const Guest = () => {
       <Button onClick={handleOpen}>Open Drawer</Button>
 
       <Drawer isOpen={open} onClose={handleClose}>
-        <div className="p-4 space-y-4">
+        <Drawer.Header title="Guest Drawer" />
+        <Drawer.Body>
           <p>Drawer Content</p>
+        </Drawer.Body>
+        <Drawer.Footer>
           <Button onClick={handleClose}>Close Drawer</Button>
-        </div>
+        </Drawer.Footer>
       </Drawer>
     </div>
   );

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -61,11 +61,13 @@ const Users = () => {
     <>
       <Table key={tableKey} tableConfig={usersTableConfig} />
       <Drawer
-        title="Add User"
         isOpen={drawerOpen}
         onClose={() => setDrawerOpen(false)}
       >
-        <AddUserForm onSuccess={handleAddUserSuccess} />
+        <Drawer.Header title="Add User" />
+        <Drawer.Body>
+          <AddUserForm onSuccess={handleAddUserSuccess} />
+        </Drawer.Body>
       </Drawer>
     </>
   );


### PR DESCRIPTION
## Summary
- refactor the Drawer component to mount through a shared Portal and provide header, body, and footer slots
- add Drawer context-aware subcomponents and tests for the new API
- update Guest and Users pages to consume the new Drawer structure

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68ca6fc4ce08833298982ab366d70915